### PR TITLE
Adding Missing dropdown step

### DIFF
--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -70,6 +70,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "newman": "^1.2.9",
     "phantomjs": "^1.9.15",
-    "xml": "~0.0.12"
+    "xml": "~0.0.12",
+    "protractor-cucumber": "^0.1.4"
   }
 }

--- a/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
@@ -1,9 +1,10 @@
 var CAM_MOCKS = require('../../../common/mock-data.js');
 var SSTEPS = require('../../shared_steps.js');
 
-this.Given(SSTEPS.appStarted.regex, SSTEPS.appStarted.fn)
-
 var channelSubscriberDropdown_steps = module.exports = function(){
+
+  this.Given(SSTEPS.appStarted.regex, SSTEPS.appStarted.fn)
+  
   this.When(/^I select a channel from the list$/, function (next) {
     element.all(by.css("#collection-channels .channel-item")).get(0).click()
     .then(next);

--- a/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
@@ -1,6 +1,9 @@
 var CAM_MOCKS = require('../../../common/mock-data.js');
 var SA_STEPS = require('../../sharedAPI_steps.js');
 
+this.Given(SA_STEPS.appStarted.regex,
+    SA_STEPS.appStarted.fn)
+
 var channelSubscriberDropdown_steps = module.exports = function(){
   this.When(/^I select a channel from the list$/, function (next) {
     element.all(by.css("#collection-channels .channel-item")).get(0).click()

--- a/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/channelSubscriberDropdown_steps.js
@@ -1,8 +1,7 @@
 var CAM_MOCKS = require('../../../common/mock-data.js');
-var SA_STEPS = require('../../sharedAPI_steps.js');
+var SSTEPS = require('../../shared_steps.js');
 
-this.Given(SA_STEPS.appStarted.regex,
-    SA_STEPS.appStarted.fn)
+this.Given(SSTEPS.appStarted.regex, SSTEPS.appStarted.fn)
 
 var channelSubscriberDropdown_steps = module.exports = function(){
   this.When(/^I select a channel from the list$/, function (next) {


### PR DESCRIPTION
The step definitions for channelSubscriberDropdown feature were missing the "Given" step. Although this test passed when run with a group that included a requirement for shared_steps.js, it was missing that setup step when run alone.