### PR TITLE
populate-couchdb-mocks.js: Now with non-default --wipe flag

### DIFF
--- a/apps/chat/couchdb/mocks/pwdcreds1.json
+++ b/apps/chat/couchdb/mocks/pwdcreds1.json
@@ -1,4 +1,5 @@
 {
+  "_id": "pwdcred-1",
   "soproModel":"pwdcred",
   "for_userid":"user-abc",
   "salt":"aaaa",

--- a/apps/chat/couchdb/mocks/pwdcreds2.json
+++ b/apps/chat/couchdb/mocks/pwdcreds2.json
@@ -1,4 +1,5 @@
 {
+  "_id": "pwdcred-2",
   "soproModel":"pwdcred",
   "for_userid":"user-xyz",
   "salt":"aaaa",

--- a/apps/chat/couchdb/mocks/pwdcreds3.json
+++ b/apps/chat/couchdb/mocks/pwdcreds3.json
@@ -1,4 +1,5 @@
 {
+  "_id": "pwdcred-3",
   "soproModel":"pwdcred",
   "for_userid":"user-999",
   "salt":"aaaa",

--- a/apps/chat/couchdb/populate-couchdb-mocks.js
+++ b/apps/chat/couchdb/populate-couchdb-mocks.js
@@ -1,4 +1,6 @@
 var glob = require('glob');
+var argh = require('argh').argv;
+
 // This script wipes out, recreates, and populates the 'mocks' database.
 var config = require('../cfg/servers.js').couchdb;
 
@@ -19,33 +21,44 @@ var async = require('async');
 var fs = require('fs');
 
 async.series([
-  destroyOldTestDb,
-  createTestDb,
+  destroyOldTestDbIfWipe,
+  ensureTestDb,
   populateDesignDocs,
   populateTestDb,
 ], function(err){
-  if(err){ throw new Error(err)}
+  if(err){
+    throw new Error(err)
+  }
   console.log('Successfully (re)generated mock couchdb')
   process.exit();
 })
 
-function destroyOldTestDb(done){
-  nano.db.destroy('mocks', function(err, body, headers){
-    if(err){
-      if(err.error !== "not_found"){
-        throw(err);
+function destroyOldTestDbIfWipe(done){
+  if(argh.wipe){
+    nano.db.destroy('mocks', function(err, body, headers){
+      if(err){
+        if(err.error !== "not_found"){
+          throw(err);
+        }
       }
-    }
+      done();
+    });
+  } else {
     done();
-  });
+  }
 }
 
-function createTestDb(done){
+function ensureTestDb(done){
   nano.db.create('mocks', function(err, body, headers){
     if(err){
-      return done(err)
+      if(err.error === "file_exists"){
+        return done()
+      } else {
+        return done(err)
+      };
+    } else {
+      return done();
     }
-    done();
   });
 }
 
@@ -54,7 +67,23 @@ function populateDesignDocs(done){
   var soprochatJSON = fs.readFileSync('./soprochat-views.json');
   var soprochat = JSON.parse(soprochatJSON);
   // Not using PI.create because design docs don't have a .soproModel property
-  mocks.insert(soprochat, soprochat._id, done)
+  mocks.get(soprochat._id, { revs_info: true }, function(err, doc){
+    if(err){
+      if(err.error === 'not_found'){
+      } else {
+        return done(err);
+      }
+    } else {
+      soprochat._rev = doc._rev
+    }
+    mocks.insert(soprochat, soprochat._id, function(err){
+      if(err){
+        return done(err)
+      } else {
+        return done()
+      };
+    })
+  });
 }
 
 function populateTestDb(callback){
@@ -63,9 +92,21 @@ function populateTestDb(callback){
     console.log('Populating', files.length, 'mocks')
     async.eachSeries(files, function(path, done){
       var json = fs.readFileSync(path);
-      var doc = JSON.parse(json);
-      PI.create(doc.soproModel, doc, done)
-    })
+      var mock = JSON.parse(json);
+      //PI.create(doc.soproModel, doc, done)
+      PI.read(mock._id, function(err, doc){
+        if(err){
+          if(err.error === 'not_found'){
+            PI.create(mock.soproModel, mock, done)
+          } else{
+            return done(err)
+          };
+        } else {
+          mock._rev = doc._rev;
+          PI.update(mock.soproModel, mock, done)
+        }
+      });
+    }, callback)
   })
 
 

--- a/apps/chat/couchdb/populate-couchdb-mocks.js
+++ b/apps/chat/couchdb/populate-couchdb-mocks.js
@@ -93,7 +93,6 @@ function populateTestDb(callback){
     async.eachSeries(files, function(path, done){
       var json = fs.readFileSync(path);
       var mock = JSON.parse(json);
-      //PI.create(doc.soproModel, doc, done)
       PI.read(mock._id, function(err, doc){
         if(err){
           if(err.error === 'not_found'){

--- a/apps/chat/persistence-couchdb.js
+++ b/apps/chat/persistence-couchdb.js
@@ -33,8 +33,11 @@ couch.readAll = function(model, callback) {
 };
 
 couch.update = function(data, callback){
-  assert(data._id);
-  assert(data._rev);
+  if(data._id === undefined){
+    return callback('Cannot update couch data without _id property')
+  } else if(data._rev === undefined){
+    return callback('Cannot update couch data without _rev property')
+  }
   db.insert(data, data._id, function(err, body){
     if(err){
       return callback(err);

--- a/apps/chat/tests/acceptance/.jenkins.sh
+++ b/apps/chat/tests/acceptance/.jenkins.sh
@@ -21,7 +21,7 @@ cd ../..
 npm install
 
 cd couchdb
-node populate-couchdb-mocks.js
+node populate-couchdb-mocks.js --wipe
 cd ..
 
 # Redirect stdout, but not stderr:

--- a/apps/chat/tests/api/.jenkins.sh
+++ b/apps/chat/tests/api/.jenkins.sh
@@ -12,7 +12,7 @@ sleep 10
 npm install
 
 cd couchdb
-node populate-couchdb-mocks.js
+node populate-couchdb-mocks.js --wipe
 cd ..
 
 # Redirect stdout, but not stderr:

--- a/apps/chat/tests/gui/.jenkins.sh
+++ b/apps/chat/tests/gui/.jenkins.sh
@@ -16,7 +16,7 @@ sleep 10
 npm install
 
 cd couchdb
-node populate-couchdb-mocks.js
+node populate-couchdb-mocks.js --wipe
 cd ..
 
 # Redirect stdout, but not stderr:

--- a/apps/chat/tests/unit-backend/.jenkins.sh
+++ b/apps/chat/tests/unit-backend/.jenkins.sh
@@ -1,5 +1,5 @@
 npm install
 cd couchdb
-node populate-couchdb-mocks.js
+node populate-couchdb-mocks.js --wipe
 cd ..
 npm run unit-backend


### PR DESCRIPTION
Previously the `couchdb/populate-couchdb-mocks.js` script always wiped out the whole database before adding design documents and mock data.

Now that we have demo users and a demo site, we should avoid wiping out any user-provided messages and other data, when possible.

So, the script now prefers to *update* the database's design documents and mock data documents, to the versions on disk, *without* clearing the rest of the database.

If you **do** want to reset everything, invoke the script like:

    cd apps/chat/couchdb
    node populate-couchdb-mocks.js --wipe