### PR TITLE
Validate new user password form

### DIFF
--- a/apps/chat/bower.json
+++ b/apps/chat/bower.json
@@ -19,6 +19,7 @@
     "material-design-icons": "~1.0.1",
     "angular-mocks": "~1.3.13",
     "jquery": "~2.1.3",
-    "perfect-scrollbar": "~0.6.1"
+    "perfect-scrollbar": "~0.6.1",
+    "angular-ui-utils": "~0.0.4"
   }
 }

--- a/apps/chat/tests/acceptance/features/newUserActivationLink.feature
+++ b/apps/chat/tests/acceptance/features/newUserActivationLink.feature
@@ -3,6 +3,12 @@ Feature: New user activation link
   I want to receive an activation link when my user is created
   So that I can securely set a password on my user account
 
+  Scenario: mismatched passwords
+    Given I have an valid activation token
+    When I visit the confirm account page for that token
+      And I set mismatched passwords
+    Then I should not be able to submit the form
+
   Scenario: valid activation link
     Given I have a valid activation token
     When I visit the confirm account page for that token
@@ -20,9 +26,3 @@ Feature: New user activation link
     Given I have an invalid activation token
     When I visit the confirm account page for that token
     Then I should see a failure message
-
-  Scenario: mismatched passwords
-    Given I have an valid activation token
-    When I visit the confirm account page for that token
-      And I set mismatched passwords
-    Then I should not be able to submit the form

--- a/apps/chat/tests/acceptance/features/newUserActivationLink.feature
+++ b/apps/chat/tests/acceptance/features/newUserActivationLink.feature
@@ -20,3 +20,9 @@ Feature: New user activation link
     Given I have an invalid activation token
     When I visit the confirm account page for that token
     Then I should see a failure message
+
+  Scenario: mismatched passwords
+    Given I have an valid activation token
+    When I visit the confirm account page for that token
+      And I set mismatched passwords
+    Then I should not be able to submit the form

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -60,6 +60,7 @@ module.exports = function(){
   this.When(/^I visit the confirm account page for that token$/,function (next) {
     var self = this;
     var uri = 'https://' + this.app.sopro.servers.express.hostname + '/confirmAccount/' + this.tokenObj.token
+    console.log(uri);
     browser.driver.get(uri)
     .then(function () {
       browser.driver.getPageSource()

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -60,7 +60,6 @@ module.exports = function(){
   this.When(/^I visit the confirm account page for that token$/,function (next) {
     var self = this;
     var uri = 'https://' + this.app.sopro.servers.express.hostname + '/confirmAccount/' + this.tokenObj.token
-    console.log(uri);
     browser.driver.get(uri)
     .then(function () {
       browser.driver.getPageSource()
@@ -85,13 +84,11 @@ module.exports = function(){
       .sendKeys(self.password);
       pwd2
       .sendKeys(self.password);
-       // browser.ignoreSynchronization = true;
 
       element(by.css('input[type="submit"]'))
       .click()
       .then(function(){
         next();
-        //browser.ignoreSynchronization = false;
       });
     });
   });
@@ -111,9 +108,7 @@ module.exports = function(){
       .sendKeys(self.password);
       pwd2
       .sendKeys(self.passwordConfirm);
-        //browser.ignoreSynchronization = true;
       next();
-      //browser.ignoreSynchronization = false;
     });
   });
 

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -59,7 +59,7 @@ module.exports = function(){
 
   this.When(/^I visit the confirm account page for that token$/,function (next) {
     var self = this;
-    var uri = 'https://' + this.app.sopro.servers.express.hostname + '/confirmAccount/' + this.tokenObj.token
+    var uri = this.app.sopro.servers.express.baseUrl + '/confirmAccount/' + this.tokenObj.token
     browser.driver.get(uri)
     .then(function () {
       browser.driver.getPageSource()
@@ -85,12 +85,33 @@ module.exports = function(){
       pwd2
       .sendKeys(self.password);
         browser.ignoreSynchronization = true;
+
       element(by.css('input[type="submit"]'))
       .click()
       .then(function(){
         next();
         browser.ignoreSynchronization = false;
       });
+    });
+  });
+
+  this.When(/^I set mismatched passwords$/, function (next) {
+    var self = this;
+    self.password = "password";
+    self.passwordConfirm = "pa55word";
+    var pwd1 = element(by.css("input[name=password1]"));
+    var pwd2 = element(by.css("input[name=password2]"));
+
+    element(by.css("input[name=password1]"))
+    .isDisplayed()
+    .then(function (isDisplayed) {
+      assert(isDisplayed);
+      pwd1
+      .sendKeys(self.password);
+      pwd2
+      .sendKeys(self.passwordConfirm);
+        browser.ignoreSynchronization = true;
+      next();
     });
   });
 
@@ -152,4 +173,16 @@ module.exports = function(){
   //Given I have an invalid activation link
   //When I visit the confirm account page
   //Then I should see a failure message
+
+  this.Then(/^I should not be able to submit the form$/, function (next) {
+    element(by.css('input[type="submit"]'))
+    .getAttribute('disabled')
+    .then(function (attr) {
+      if (attr == false) {
+        next.fail(new Error('Expected submit button to be disabled'));
+      } else {
+        next();
+      }
+    });
+  });
 }

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -112,6 +112,7 @@ module.exports = function(){
       .sendKeys(self.passwordConfirm);
         browser.ignoreSynchronization = true;
       next();
+      browser.ignoreSynchronization = false;
     });
   });
 

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -85,13 +85,13 @@ module.exports = function(){
       .sendKeys(self.password);
       pwd2
       .sendKeys(self.password);
-        browser.ignoreSynchronization = true;
+       // browser.ignoreSynchronization = true;
 
       element(by.css('input[type="submit"]'))
       .click()
       .then(function(){
         next();
-        browser.ignoreSynchronization = false;
+        //browser.ignoreSynchronization = false;
       });
     });
   });
@@ -111,9 +111,9 @@ module.exports = function(){
       .sendKeys(self.password);
       pwd2
       .sendKeys(self.passwordConfirm);
-        browser.ignoreSynchronization = true;
+        //browser.ignoreSynchronization = true;
       next();
-      browser.ignoreSynchronization = false;
+      //browser.ignoreSynchronization = false;
     });
   });
 

--- a/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
+++ b/apps/chat/tests/acceptance/features/step_definitions/newUserActivationLink_steps.js
@@ -59,7 +59,7 @@ module.exports = function(){
 
   this.When(/^I visit the confirm account page for that token$/,function (next) {
     var self = this;
-    var uri = this.app.sopro.servers.express.baseUrl + '/confirmAccount/' + this.tokenObj.token
+    var uri = 'https://' + this.app.sopro.servers.express.hostname + '/confirmAccount/' + this.tokenObj.token
     browser.driver.get(uri)
     .then(function () {
       browser.driver.getPageSource()

--- a/apps/chat/views/confirmAccount.ejs
+++ b/apps/chat/views/confirmAccount.ejs
@@ -11,30 +11,10 @@
     <script type="text/javascript" src="/web/bower_components/angular-aria/angular-aria.js"></script>
     <script type="text/javascript" src="/web/bower_components/angular-animate/angular-animate.js"></script>
     <script type="text/javascript" src="/web/bower_components/angular-material/angular-material.js"></script>
+    <script type="text/javascript" src="/web/bower_components/angular-ui-utils/ui-utils.js"></script>
     <script type="text/javascript">
-      var $p1;
-      var $p2;
-      $(document).ready(function(){
-        $p1 = $('input[name="password1"]');
-        $p2 = $('input[name="password2"]');
-        $matchHint = $('#matchHint');
-        console.log($p1);
-        $p1.on('keyup', validatePwd)
-        $p2.on('keyup', validatePwd)
-        function validatePwd(e){
-          console.log(e);
-          if($p1.val() !== $p2.val()){
-            $matchHint.show();
-          } else {
-            $matchHint.hide();
-          }
-        }
-      })
+      angular.module('confirmAccount', ['ngMaterial', 'ui.utils'])
     </script>
-    <script type="text/javascript">
-      angular.module('confirmAccount', ['ngMaterial'])
-    </script>
-
 </head>
 <body layout="column" layout-fill data-soproenv="<%= config.env %>">
   <md-toolbar layout="row">
@@ -44,20 +24,22 @@
     <md-content flex layout="column" layout-wrap id="main-stage">
       <p>Welcome to the haven of Captains of Society Pro<% if (currentUser) { %>, <%= currentUser.username %><% } %>!</p>
       <p>Please set your password:</p>
-      <form action="/confirmAccount/done" method="POST">
+      <form action="/confirmAccount/done" method="POST" name="passwordForm">
         <div layout="row">
           <md-input-container>
             <label> Password: </label>
-            <input type="password" name="password1"></input>
+            <input type="password" name="password1" ng-model="password1" ng-required="true"></input>
           </md-input-container>
           <md-input-container>
             <label> Password again: </label>
-            <input type="password" name="password2"></input>
+            <input type="password" name="password2" ng-model="password2" ui-validate=" '$value==password1' " ui-validate-watch=" 'password1' " ng-required="true"></input>
+            <div ng-messages="passwordForm.password2.$error" ng-show="passwordForm.password2.$dirty && passwordForm.password2.$error.validator">
+              <div ng-message="validator">The passwords don't match!</div>
+            </div>
           </md-input-container>
         </div>
-        <span block hidden id="matchHint">Passwords do not match</span>
         <input type="hidden" name="token" value="<%= token %>">
-        <input block type="submit" value="Submit"></input>
+        <input block type="submit" value="Submit" ng-disabled="passwordForm.$invalid"></input>
       </form>
     </md-content>
   </div>


### PR DESCRIPTION
This addresses https://github.com/SocietyPro/sopro/issues/33

- Adds acceptance test scenario to the password form to test that the form cannot be submitted with mismatched passwords
- Implements ui.utils password matching
- Implements angular material validation text